### PR TITLE
Address webhint.io hints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,17 @@
+[[headers]]
+    for = "/*"
+    [headers.values]
+        Cache-Control = "public, max-age=31536000, immutable"
+        X-Content-Type-Options = "nosniff"
+[[headers]]
+    for = "/"
+    [headers.values]
+        Cache-Control = "public, no-cache"
+[[headers]]
+    for = "/manifest.webmanifest"
+    [headers.values]
+        Content-Type = "application/manifest+json; charset=utf-8"
+
 [[plugins]]
 package = "netlify-plugin-subfont"
     [plugins.inputs]

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,14 +11,3 @@
     for = "/manifest.webmanifest"
     [headers.values]
         Content-Type = "application/manifest+json; charset=utf-8"
-
-[[plugins]]
-package = "netlify-plugin-subfont"
-    [plugins.inputs]
-    # Inline generated CSS @font-face blocks into each page
-    # When set to `false` an external CSS file will be created
-    inlineCss = true
-
-    # Inline generated font subsets into their respective @font-face blocks
-    # When set to `false` external font files will be created
-    inlineFonts = true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "workbox-cli": "^6.1.5"
   },
   "scripts": {
-    "build": "rm -r dist && eleventy && workbox generateSW workbox-config.js",
+    "build": "eleventy && workbox generateSW workbox-config.js",
+    "clean": "rm -r dist",
     "start": "eleventy --serve"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "workbox-cli": "^6.1.5"
   },
   "scripts": {
-    "build": "eleventy && workbox generateSW workbox-config.js",
+    "build": "rm -r dist && eleventy && workbox generateSW workbox-config.js",
     "start": "eleventy --serve"
   },
   "keywords": [],

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <meta name="description" content="{{ renderData.description or description or metadata.description }}">
     <title>{{ renderData.title or title or metadata.title }}</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">

--- a/src/manifest.njk
+++ b/src/manifest.njk
@@ -2,7 +2,7 @@
 permalink: "manifest.webmanifest"
 ---
 {
-  "name": "Jesper Nellemann Jakobsen's site",
+  "name": "Jesper N. Jakobsen's site",
   "short_name": "jespers.site",
   "start_url": ".",
   "display": "standalone",


### PR DESCRIPTION
Make changes based on webhint report:
https://webhint.io/scanner/ec68d251-b1dd-4322-80f8-4199e5d57422

Set long, immutable cache for everything but landing page.
Add `nosniff` X-Content-Type-Option.
Remove X-UA-Compatible meta tag.
Set correct Content-Type header for `manifest.webmanifest`.
Shorten manifest long name to something less than 30 characters.